### PR TITLE
Run full tox tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 dist: trusty
 
+python:
+- 2.7
+- 3.6
+
 git:
   depth: 10
 
@@ -41,25 +45,21 @@ env:
     - COVERALLS_PARALLEL=true
     - PGPORT=5433
     - TEST_DATABASE_URL=postgres://travis:travis@localhost:5433/travis
+    - TRAVIS_CHECK_MIGRATIONS="./manage.py makemigrations --dry-run --check"
+  matrix:
+    - RUNTEST=backend
+    - RUNTEST=frontend
+
+matrix:
+  exclude:
+    # We only want to run the frontend build once.
+    - python: 2.7
+      env: RUNTEST=frontend
 
 jobs:
-  fast_finish: true
   include:
-    - stage: Run Tests
-      env: RUNTEST=frontend
-      if: type = pull_request
-      python: 2.7
-    - env:
-        - RUNTEST=backend
-        - TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner
-      if: type = pull_request
-      python: 2.7
-    - env:
-        - RUNTEST=backend3
-        - TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner
-      if: type = pull_request
-      python: 3.6
-    - stage: Docs Deploy
+    # This stage will run after the default testing stage succeeds.
+    - stage: Build docs and push them to GitHub Pages
       if: type != pull_request
       env: RUNTEST=docs
       deploy:

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,3 +1,4 @@
 coverage==4.5.1
-tox-pip-extensions==1.1.0
 tox==2.9.1
+tox-pip-extensions==1.1.0
+tox-travis==0.12

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ envlist=lint-py{27}, unittest-py{27,36}-dj{111}-wag{113}-slow
 # Factors:
 #   lint:               Lint Python files with flake8 and isort
 #   unittest:           Run Python unittests
-#   missing-migrations: Test for missing Django migrations
 #   acceptance:         Run a Django server and acceptance tests
 #   py27:               Use Python 2.7
 #   py36:               Use Python 3.6
@@ -27,7 +26,6 @@ envlist=lint-py{27}, unittest-py{27,36}-dj{111}-wag{113}-slow
 #   lint-py{27,36}
 #   unittest-py{27,36}-dj{111}-wag{113}-{fast,slow}
 #   unittest-py{36}-dj{20}-wag{20}-{fast,slow}
-#   missing-migrations-py{27,36}-dj{111}-wag{113}
 #   acceptance-py{27,36}-dj{111}-wag{113}-fast
 #
 # These factors are expected to combine to be invoked with:
@@ -40,7 +38,6 @@ envlist=lint-py{27}, unittest-py{27,36}-dj{111}-wag{113}-slow
 #   tox -e unittest-py36-dj111-wag113-slow
 #   tox -e unittest-py36-dj20-wag20-fast
 #   tox -e unittest-py36-dj20-wag20-slow
-#   tox -e missing-migrations-py36-dj111-wag113
 #   tox -e acceptance-py27-dj111-wag113-fast
 #   tox -e acceptance-py36-dj111-wag113-fast
 
@@ -51,7 +48,6 @@ whitelist_externals=echo
 changedir=
     unittest:           {[unittest]changedir}
     acceptance:         {[acceptance]changedir}
-    missing-migrations: {[missing-migrations]changedir}
 
 basepython=
     py27: python2.7
@@ -65,7 +61,6 @@ deps=
     lint:               {[lint]deps}
     unittest:           {[unittest]deps}
     acceptance:         {[acceptance]deps}
-    missing-migrations: {[missing-migrations]deps}
 
 passenv=
     fast:       {[unittest]passenv}
@@ -76,15 +71,14 @@ passenv=
 setenv=
     fast:               {[fast]setenv}
     slow:               {[slow]setenv}
-    missing-migrations: {[missing-migrations]setenv}
     unittest:           {[unittest]setenv}
     acceptance:         {[acceptance]setenv}
 
 commands=
     lint:               {[lint]commands}
+    py27-slow:          {[py27-slow]commands}
     unittest:           {[unittest]commands}
     acceptance:         {[acceptance]commands}
-    missing-migrations: {[missing-migrations]commands}
 
 
 [lint]
@@ -150,21 +144,17 @@ setenv=
     DJANGO_SETTINGS_MODULE=cfgov.settings.test
 
 
-[missing-migrations]
-# Configuration values necessary to run missing migrations test.
-# Note: This is not an env will not run if invoked. Use an invocation of:
+[py27-slow]
+# Extra configuration values used as part of py27-slow environments.
 #
-#   tox -e missing-migrations-py{27,36}-dj111-wag113
+# When running on Travis, we want to verify that Django migrations are
+# up-to-date. But we don't want to do that when running tox locally. We
+# accomplish this by having Travis set the TRAVIS_CHECK_MIGRATIONS
+# environment variable with the check migrations command.
 #
-# To run unit tests.
-changedir=
-    {[unittest]changedir}
-deps=
-    {[unittest]deps}
-setenv=
-    DJANGO_SETTINGS_MODULE=cfgov.settings.test
+# When not running on Travis, we want this to be a noop.
 commands=
-    ./manage.py makemigrations --dry-run --check
+    {env:TRAVIS_CHECK_MIGRATIONS:echo "Skipping Travis-only step"}
 
 
 [acceptance]
@@ -222,23 +212,6 @@ setenv=
     {[fast]setenv}
     {[unittest]setenv}
 commands={[unittest]commands}
-
-
-[testenv:missing-migrations]
-# Invoke with: tox -e missing-migrations
-# This should run identically to tox -e unittest-py27-dj111-wag113-fast
-recreate=False
-changedir={[missing-migrations]changedir}
-basepython=python2.7
-envdir={toxworkdir}/unittest-py27-dj111-wag113-fast
-deps=
-    -r{toxinidir}/requirements/django.txt
-    -r{toxinidir}/requirements/wagtail.txt
-    {[missing-migrations]deps}
-setenv=
-    {[fast]setenv}
-    {[missing-migrations]setenv}
-commands={[missing-migrations]commands}
 
 
 [testenv:acceptance]

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -21,8 +21,6 @@ if [ "$RUNTEST" == "frontend" ]; then
     backend
 elif [ "$RUNTEST" == "backend" ]; then
     backend
-elif [ "$RUNTEST" == "backend3" ]; then
-    backend
 elif [ "$RUNTEST" == "docs" ]; then
     docs
 fi

--- a/travis_run.sh
+++ b/travis_run.sh
@@ -11,13 +11,8 @@ if [ "$RUNTEST" == "frontend" ]; then
     yarn run gulp test --travis --headless
     bash <(curl -s https://codecov.io/bash) -F frontend -X coveragepy
 elif [ "$RUNTEST" == "backend" ]; then
-    tox -e lint
-    tox -e missing-migrations
-    tox -e unittest-py27-dj111-wag113-fast
+    TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner tox
     bash <(curl -s https://codecov.io/bash) -F backend
-elif [ "$RUNTEST" == "backend3" ]; then
-    tox -e lint-py36
-    tox -e unittest-py36-dj111-wag113-fast
 elif [ "$RUNTEST" == "docs" ]; then
     mkdocs build
 fi


### PR DESCRIPTION
This change modifies how the Python tests are run on Travis so that the
"slow" version is run instead of the "fast" version. The "slow" version
runs the full set of Django migrations.

It also modifies our Travis configuration to use tox-travis, which
allows us to simplify the .travis.yml a bit. This PR also removes the
separate missing-migrations environment in favor of moving the
migrations check into the standard unittest environment, but only having
it run on Travis using Python 2.7. This is accomplished via a bit of
environment variable trickery.

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
